### PR TITLE
Add optional CLI tool to handle metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,43 +30,50 @@ Command Line Interface
 
 
 The CLI version of Daiquiri Client can be installed by cloning the 
-repository and running `pip install`
+repository and running ``pip install``
 
-```bash
-clone https://github.com/django-daiquiri/client.git
-cd client && pip install .[cli]
-```
 
-__Examples__:
+.. code:: bash
+
+    clone https://github.com/django-daiquiri/client.git
+    cd client && pip install .[cli]
+
+
+**Examples**:
 
 List all metadata
-```bash
-dqclient metadata ls -h <host> -t <token>
-```
-- `<host>`: Site url, for instance `https://gaia.aip.de`
-- `<token>`: API token that is provided by every Daqiuiri app in the user settings
+
+.. code:: bash
+
+    dqclient metadata ls -h <host> -t <token>
+
+- ``<host>``: Site url, for instance `https://gaia.aip.de`
+- ``<token>``: API token that is provided by every Daqiuiri app in the user settings
 
 
 
 Pull all metadata:
 
-```bash
-dqclient metadata pull -h <host> -t <token> -o <output_file>
-```
-- `<output_file>`: output yaml file, for instance `metadata.yaml`
+.. code:: bash
+
+    dqclient metadata pull -h <host> -t <token> -o <output_file>
+
+- ``<output_file>``: output yaml file, for instance `metadata.yaml`
 
 
 The updated metadata can be pushed back to the Daiquiri website with:
 
-```bash
-dqclient metadata push -h <host> -t <token> -i <input_file>
-```
+.. code:: bash
+
+    dqclient metadata push -h <host> -t <token> -i <input_file>
+
 
 
 It is possible to push/pull specific metadata by choosing the schemas or tables
 
-```bash
-dqclient metadata push -h <host> -t <token> -i <input_file> --schemas schemaname1,schemaname2 --tables tablename1
-```
+.. code:: bash
+
+    dqclient metadata push -h <host> -t <token> -i <input_file> --schemas schemaname1,schemaname2 --tables tablename1
+
 
 

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ Daiquiri can be downloaded from
 Daiquiri Client provides a set of functions to use the API of a Daiquiri-powered
 website in a script. The necessary HTTP requests are abstracted in a transparent way.
 
+Additionally, Daiquiri Client provides a Command Line Interface (CLI) to manage the metadata
+in a terminal.
+
 For example, the following script gets the emails of all users:
 
 .. code:: python
@@ -19,3 +22,51 @@ For example, the following script gets the emails of all users:
 
     for profile in client.auth.get_profiles():
         print(profile['user']['email'])
+
+
+
+Command Line Interface
+----------------------
+
+
+The CLI version of Daiquiri Client can be installed by cloning the 
+repository and running `pip install`
+
+```bash
+clone https://github.com/django-daiquiri/client.git
+cd client && pip install .[cli]
+```
+
+__Examples__:
+
+List all metadata
+```bash
+dqclient metadata ls -h <host> -t <token>
+```
+- `<host>`: Site url, for instance `https://gaia.aip.de`
+- `<token>`: API token that is provided by every Daqiuiri app in the user settings
+
+
+
+Pull all metadata:
+
+```bash
+dqclient metadata pull -h <host> -t <token> -o <output_file>
+```
+- `<output_file>`: output yaml file, for instance `metadata.yaml`
+
+
+The updated metadata can be pushed back to the Daiquiri website with:
+
+```bash
+dqclient metadata push -h <host> -t <token> -i <input_file>
+```
+
+
+It is possible to push/pull specific metadata by choosing the schemas or tables
+
+```bash
+dqclient metadata push -h <host> -t <token> -i <input_file> --schemas schemaname1,schemaname2 --tables tablename1
+```
+
+

--- a/daiquiri_client/auth.py
+++ b/daiquiri_client/auth.py
@@ -1,5 +1,4 @@
-class Auth():
-
+class Auth:
     def __init__(self, client):
         self.client = client
 
@@ -16,4 +15,6 @@ class Auth():
         return self.client.put('/auth/api/profiles/%d/activate/' % pk, {})
 
     def update_profile_attributes(self, pk, attributes):
-        return self.client.patch('/auth/api/profiles/%d/' % pk, {'attributes': attributes})
+        return self.client.patch(
+            '/auth/api/profiles/%d/' % pk, {'attributes': attributes}
+        )

--- a/daiquiri_client/client.py
+++ b/daiquiri_client/client.py
@@ -11,7 +11,6 @@ from .tap import Tap
 
 
 class JSONEncoder(json.JSONEncoder):
-
     def default(self, obj):
         if isinstance(obj, datetime.date):
             return obj.strftime('%Y-%m-%d')
@@ -20,7 +19,6 @@ class JSONEncoder(json.JSONEncoder):
 
 
 class Client(object):
-
     def __init__(self, base_url, token=None):
         self.base_url = base_url
 
@@ -34,7 +32,9 @@ class Client(object):
         self.tap = Tap(self)
 
     def get(self, url, params={}, json=True):
-        response = requests.get(self.base_url + url, params=params, headers=self.headers)
+        response = requests.get(
+            self.base_url + url, params=params, headers=self.headers
+        )
         response.raise_for_status()
         return response.json() if json else response.text
 
@@ -52,7 +52,11 @@ class Client(object):
             raise e
 
     def put(self, url, data):
-        response = requests.put(self.base_url + url, data=json.dumps(data, cls=JSONEncoder), headers=self.headers)
+        response = requests.put(
+            self.base_url + url,
+            data=json.dumps(data, cls=JSONEncoder),
+            headers=self.headers,
+        )
         try:
             response.raise_for_status()
             return response.json()
@@ -61,7 +65,11 @@ class Client(object):
             raise e
 
     def patch(self, url, data):
-        response = requests.patch(self.base_url + url, data=json.dumps(data, cls=JSONEncoder), headers=self.headers)
+        response = requests.patch(
+            self.base_url + url,
+            data=json.dumps(data, cls=JSONEncoder),
+            headers=self.headers,
+        )
 
         try:
             response.raise_for_status()

--- a/daiquiri_client/metadata.py
+++ b/daiquiri_client/metadata.py
@@ -1,5 +1,4 @@
 class Metadata(object):
-
     def __init__(self, client):
         self.client = client
 

--- a/daiquiri_client/query.py
+++ b/daiquiri_client/query.py
@@ -1,5 +1,4 @@
-class Query():
-
+class Query:
     def __init__(self, client):
         self.client = client
 
@@ -13,9 +12,9 @@ class Query():
         return self.client.post('/query/api/jobs/', data)
 
     def update_job(self, pk, data):
-        return self.client.put('/query/api/jobs/%s/' % pk, {
-            'table_name': data['table_name']
-        })
+        return self.client.put(
+            '/query/api/jobs/%s/' % pk, {'table_name': data['table_name']}
+        )
 
     def delete_job(self, pk):
         self.client.delete('/query/api/jobs/%s/' % pk)

--- a/daiquiri_client/tap.py
+++ b/daiquiri_client/tap.py
@@ -1,10 +1,8 @@
-class Tap():
-
+class Tap:
     def __init__(self, client):
         self.client = client
 
     def sync(self, query, query_language='ADQL'):
-        return self.client.post('/tap/sync', {
-            'QUERY': query,
-            'LANG': query_language
-        }, json=False)
+        return self.client.post(
+            '/tap/sync', {'QUERY': query, 'LANG': query_language}, json=False
+        )

--- a/dqclient/cli.py
+++ b/dqclient/cli.py
@@ -1,0 +1,94 @@
+import click
+from functools import wraps
+
+from .metadata import MetadataCLI
+from daiquiri_client import __version__
+
+
+@click.group(help=f'Command Line Interface for Django-Daiquiri-Client. (Version: {__version__})')
+@click.version_option(__version__)
+def cli():
+    pass
+
+
+@cli.group(help='Commands for managing the metadata.', invoke_without_command=True)
+@click.pass_context
+def metadata(ctx):
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+def common_options(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    wrapper = click.option('-h', '--host', required=True, help='Host address')(wrapper)
+    wrapper = click.option('-t', '--token', required=True, help='API Token')(wrapper)
+    wrapper = click.option(
+        '-v',
+        '--verbose',
+        required=False,
+        default=False,
+        is_flag=True,
+        help='Show verbose output (with tables)',
+    )(wrapper)
+    return wrapper
+
+
+@metadata.command('ls', short_help='List metadata (schemas, tables and columns).')
+@common_options
+def ls(host: str, token: str, verbose: bool = False) -> None:
+    MetadataCLI().ls(host, token, verbose)
+
+
+@metadata.command('push', short_help='Push the metadata from the local file to host.')
+@common_options
+@click.option(
+    '--schemas',
+    required=False,
+    help='Comma-separated schemas, e.g.,  --schemas name1,name2. Push all if the option is omitted.',
+)
+@click.option(
+    '--tables',
+    required=False,
+    help='Comma-separated tables, e.g.,  --tables name1,name2. Push all if the option is omitted.',
+)
+@click.option(
+    '-i',
+    '--input',
+    required=True,
+    help='Input file (yaml)',
+)
+def push(host: str, token: str, verbose: bool, schemas: str, tables: str, input: str) -> None:
+    schemas_list = [] if schemas is None else schemas.split(',')
+    tables_list = [] if tables is None else tables.split(',')
+    MetadataCLI().push(host, token, input, schemas_list, tables_list, verbose)
+
+
+@metadata.command('pull', short_help='Pull the metadata and save it into a yaml file.')
+@common_options
+@click.option(
+    '--schemas',
+    required=False,
+    help='Comma-separated schemas, e.g.,  --schemas name1,name2. Pull all if the option is omitted.',
+)
+@click.option(
+    '--tables',
+    required=False,
+    help='Comma-separated tables, e.g.,  --tables name1,name2. Pull all if the option is omitted.',
+)
+@click.option(
+    '-o',
+    '--output',
+    required=True,
+    help='Output file',
+)
+def pull(host: str, token: str, verbose: bool, schemas: str, tables: str, output: str) -> None:
+    schemas_list = [] if schemas is None else schemas.split(',')
+    tables_list = [] if tables is None else tables.split(',')
+    MetadataCLI().pull(host, token, output, schemas_list, tables_list, verbose)
+
+
+if __name__ == '__main__':
+    cli()

--- a/dqclient/metadata.py
+++ b/dqclient/metadata.py
@@ -1,4 +1,4 @@
-from daiquiri_client import Client
+from daiquiri_client.client import Client
 import yaml
 
 
@@ -27,7 +27,7 @@ class MetadataCLI:
         with open(input, 'r') as fd:
             full_metadata = yaml.load(fd, yaml.Loader)
         try:
-            self._names_are_unique(full_metadata)
+            _ = self._names_are_unique(full_metadata)
         except ValueError as e:
             print('Some of the objects in the input file are not unique!')
             print('The script supports only unique schemas, tables and columns!')
@@ -52,6 +52,8 @@ class MetadataCLI:
                 if remote_schema['name'] == local_schema['name']:
                     print(f'Schema {local_schema["name"]}')
                     try:
+                        # clean up local metadata if originated from other tools
+                        local_schema.pop('id', None)
                         client.metadata.update_schema(remote_schema['id'], local_schema)
                     except Exception as e:
                         print(e)
@@ -63,6 +65,9 @@ class MetadataCLI:
                             if remote_table['name'] == local_table['name']:
                                 print(f' - {local_table["name"]}')
                                 try:
+                                    # clean up local metadata if originated from other tools
+                                    local_table.pop('id', None)
+                                    local_table.pop('schema', None)
                                     client.metadata.update_table(remote_table['id'], local_table)
                                 except Exception as e:
                                     print(e)
@@ -71,6 +76,9 @@ class MetadataCLI:
                                     for local_column in local_table['columns']:
                                         if remote_column['name'] == local_column['name']:
                                             try:
+                                                # clean up local metadata if originated from other tools
+                                                local_table.pop('id', None)
+                                                local_table.pop('table', None)
                                                 client.metadata.update_column(remote_column['id'], local_column)
                                             except Exception as e:
                                                 print(e)
@@ -90,7 +98,7 @@ class MetadataCLI:
         client = Client(host, token)
         sorted_metadata = client.metadata.get_schemas(nested=True)
         try:
-            self._names_are_unique(sorted_metadata)
+            _ = self._names_are_unique(sorted_metadata)
         except ValueError as e:
             print('Some of the objects are not unique! The script supports only unique schemas, tables and columns!')
             print(e)

--- a/dqclient/metadata.py
+++ b/dqclient/metadata.py
@@ -1,0 +1,127 @@
+from daiquiri_client import Client
+import yaml
+
+
+class MetadataCLI:
+    def ls(self, host: str, token: str, verbose: bool) -> dict:
+        client = Client(host, token)
+        metadata = client.metadata.get_schemas(nested=True)
+        print(f'Metadata from "{host}":')
+        for schema in metadata:
+            print(schema['name'])
+            if verbose:
+                for table in schema['tables']:
+                    print(f' - {table["name"]}')
+        return metadata
+
+    def push(
+        self,
+        host: str,
+        token: str,
+        input: str,
+        schemas: 'list[str]',
+        tables: 'list[str]',
+        verbose: bool,
+    ) -> None:
+        full_metadata = []
+        with open(input, 'r') as fd:
+            full_metadata = yaml.load(fd, yaml.Loader)
+        try:
+            self._names_are_unique(full_metadata)
+        except ValueError as e:
+            print('Some of the objects in the input file are not unique!')
+            print('The script supports only unique schemas, tables and columns!')
+            print(e)
+            return
+
+        client = Client(host, token)
+        remote_metadata = client.metadata.get_schemas(nested=True)
+        if verbose:
+            print(f'Pushing metadata to {host}')
+        for remote_schema in remote_metadata:
+            for local_schema in full_metadata:
+                if remote_schema['name'] == local_schema['name']:
+                    print(f'Schema {local_schema["name"]}')
+                    client.metadata.update_schema(remote_schema['id'], local_schema)
+                    for remote_table in remote_schema['tables']:
+                        for local_table in local_schema['tables']:
+                            if remote_table['name'] == local_table['name']:
+                                print(f' - {local_table["name"]}')
+                                client.metadata.update_table(remote_table['id'], local_table)
+                                for remote_column in remote_table['columns']:
+                                    for local_column in local_table['columns']:
+                                        if remote_column['name'] == local_column['name']:
+                                            client.metadata.update_column(remote_column['id'], local_column)
+        if verbose:
+            print('Done!')
+
+    def pull(
+        self,
+        host: str,
+        token: str,
+        output: str,
+        schemas: 'list[str]',
+        tables: 'list[str]',
+        verbose: bool,
+    ) -> None:
+        client = Client(host, token)
+        sorted_metadata = client.metadata.get_schemas(nested=True)
+        try:
+            self._names_are_unique(sorted_metadata)
+        except ValueError as e:
+            print('Some of the objects are not unique! The script supports only unique schemas, tables and columns!')
+            print(e)
+            return
+        full_metadata = []
+        if verbose:
+            print(f'Pulling metadata from {host}')
+        for remote_schema in sorted_metadata:
+            if len(schemas) == 0 or remote_schema['name'] in schemas:
+                if verbose:
+                    print(f'Schema: {remote_schema["name"]}')
+                new_schema = client.metadata.get_schema(remote_schema['id'])
+                new_schema.pop('id')
+                new_schema['tables'] = []
+                for remote_table in remote_schema['tables']:
+                    if len(tables) == 0 or remote_table['name'] in tables:
+                        if verbose:
+                            print(f' - {remote_table["name"]}')
+                        new_table = client.metadata.get_table(remote_table['id'])
+                        new_table.pop('id')
+                        new_table.pop('schema')
+                        new_table['columns'] = []
+                        for remote_column in remote_table['columns']:
+                            new_col = client.metadata.get_column(remote_column['id'])
+                            new_col.pop('id')
+                            new_col.pop('table')
+                            new_table['columns'].append(new_col)
+                        new_schema['tables'].append(new_table)
+                full_metadata.append(new_schema)
+        with open(output, 'w+') as fd:
+            yaml.dump(full_metadata, fd, sort_keys=False)
+
+    def _names_are_unique(self, metadata: 'list[dict]') -> bool:
+        """Checks that schema, table, and column names are unique within their respective scopes."""
+        error_message = ''
+        schema_names = [schema['name'] for schema in metadata]
+        duplicate_schema_names = [s for s in schema_names if schema_names.count(s) > 1]
+        if len(duplicate_schema_names) > 0:
+            error_message += 'Duplicate schemas: ' + ', '.join(set(duplicate_schema_names)) + ';\n'
+        duplicate_table_names = []
+        duplicate_column_names = []
+        for schema in metadata:
+            table_names = [f'{schema["name"]}.{table["name"]}' for table in schema['tables']]
+            duplicate_table_names.extend([t for t in table_names if table_names.count(t) > 1])
+            for table in schema['tables']:
+                column_names = [f'{schema["name"]}.{table["name"]}.{column["name"]}' for column in table['columns']]
+                duplicate_column_names.extend([c for c in column_names if column_names.count(c) > 1])
+
+        if len(duplicate_table_names) > 0:
+            error_message += 'Duplicate tables: ' + ', '.join(set(duplicate_table_names)) + ';\n'
+        if len(duplicate_column_names) > 0:
+            error_message += 'Duplicate columns: ' + ', '.join(set(duplicate_column_names)) + ';\n'
+
+        if error_message != '':
+            raise ValueError(error_message)
+
+        return True

--- a/dqclient/metadata.py
+++ b/dqclient/metadata.py
@@ -97,6 +97,13 @@ class MetadataCLI:
             print(e)
             return
         full_metadata = []
+        # check if the tables/schemas provided as arguments exist in the remote metadata
+        if len(schemas) > 0:
+            remote_schemas = [schema['name'] for schema in sorted_metadata]
+            for schema in schemas:
+                if schema not in remote_schemas:
+                    print(f'The schema "{schema}" does not exist on the host!')
+                    return
         if verbose:
             print(f'Pulling metadata from {host}')
         for remote_schema in sorted_metadata:

--- a/dqclient/metadata.py
+++ b/dqclient/metadata.py
@@ -38,7 +38,6 @@ class MetadataCLI:
         remote_metadata = client.metadata.get_schemas(nested=True)
         if verbose:
             print(f'Pushing metadata to {host}')
-
         # check if the tables/schemas provided as arguments exist in the remote metadata
         if len(schemas) > 0:
             remote_schemas = [schema['name'] for schema in remote_metadata]
@@ -61,7 +60,7 @@ class MetadataCLI:
                         for local_table in local_schema['tables']:
                             if len(tables) > 0 and remote_table['name'] not in tables:
                                 continue
-                            if remote_table['name'] in tables and remote_table['name'] == local_table['name']:
+                            if remote_table['name'] == local_table['name']:
                                 print(f' - {local_table["name"]}')
                                 try:
                                     client.metadata.update_table(remote_table['id'], local_table)

--- a/dqclient/metadata.py
+++ b/dqclient/metadata.py
@@ -38,20 +38,44 @@ class MetadataCLI:
         remote_metadata = client.metadata.get_schemas(nested=True)
         if verbose:
             print(f'Pushing metadata to {host}')
+
+        # check if the tables/schemas provided as arguments exist in the remote metadata
+        if len(schemas) > 0:
+            remote_schemas = [schema['name'] for schema in remote_metadata]
+            for schema in schemas:
+                if schema not in remote_schemas:
+                    print(f'The schema "{schema}" does not exist on the host!')
+                    return
         for remote_schema in remote_metadata:
             for local_schema in full_metadata:
+                if len(schemas) > 0 and remote_schema['name'] not in schemas:
+                    continue
                 if remote_schema['name'] == local_schema['name']:
                     print(f'Schema {local_schema["name"]}')
-                    client.metadata.update_schema(remote_schema['id'], local_schema)
+                    try:
+                        client.metadata.update_schema(remote_schema['id'], local_schema)
+                    except Exception as e:
+                        print(e)
+                        return
                     for remote_table in remote_schema['tables']:
                         for local_table in local_schema['tables']:
-                            if remote_table['name'] == local_table['name']:
+                            if len(tables) > 0 and remote_table['name'] not in tables:
+                                continue
+                            if remote_table['name'] in tables and remote_table['name'] == local_table['name']:
                                 print(f' - {local_table["name"]}')
-                                client.metadata.update_table(remote_table['id'], local_table)
+                                try:
+                                    client.metadata.update_table(remote_table['id'], local_table)
+                                except Exception as e:
+                                    print(e)
+                                    return
                                 for remote_column in remote_table['columns']:
                                     for local_column in local_table['columns']:
                                         if remote_column['name'] == local_column['name']:
-                                            client.metadata.update_column(remote_column['id'], local_column)
+                                            try:
+                                                client.metadata.update_column(remote_column['id'], local_column)
+                                            except Exception as e:
+                                                print(e)
+                                                return
         if verbose:
             print('Done!')
 

--- a/examples/update_metadata.py
+++ b/examples/update_metadata.py
@@ -16,12 +16,12 @@ for remote_schema in client.metadata.get_schemas(nested=True):
 
             for remote_table in remote_schema['tables']:
                 for local_table in local_schema['tables']:
-
                     if remote_table['name'] == local_table['name']:
                         client.metadata.update_table(remote_table['id'], local_table)
 
                         for remote_column in remote_table['columns']:
                             for local_column in local_table['columns']:
-
                                 if remote_column['name'] == local_column['name']:
-                                    client.metadata.update_column(remote_column['id'], local_column)
+                                    client.metadata.update_column(
+                                        remote_column['id'], local_column
+                                    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,44 +1,47 @@
 [build-system]
-requires = [
-    "setuptools",
-]
-build-backend = "setuptools.build_meta"
+requires = ['setuptools']
+build-backend = 'setuptools.build_meta'
 
 [project]
-name = "django-daiquiri-client"
-description = "Daiquiri Client is a python library meant to be used with the Daiquiri Framework."
-readme = "README.rst"
-dynamic = ["version"]
-license = {text = "Apache-2.0"}
-authors = [
-    {name = "Jochen Klar", email = "jklar@aip.de"},
-]
-maintainers = [
-    {name = "Kirill Makan", email = "kmakan@aip.de"},
-]
-requires-python = ">=3.9"
+name = 'django-daiquiri-client'
+description = 'Daiquiri Client is a python library meant to be used with the Daiquiri Framework.'
+readme = 'README.rst'
+dynamic = ['version']
+license = { text = 'Apache-2.0' }
+authors = [{ name = 'Jochen Klar', email = 'jklar@aip.de' }]
+maintainers = [{ name = 'Kirill Makan', email = 'kmakan@aip.de' }]
+requires-python = '>=3.9'
 classifiers = [
-    'Development Status :: 4 - Beta', # 3 - Alpha, 4 - Beta, 5 - Production/Stable, 6 - Mature, 7 - Inactive (1 - Planning)
-    'Intended Audience :: Developers',
-    'Intended Audience :: System Administrators',
-    "Programming Language :: Python :: 3",
-    "Operating System :: Linux and OSX",
+  'Development Status :: 4 - Beta', # 3 - Alpha, 4 - Beta, 5 - Production/Stable, 6 - Mature, 7 - Inactive (1 - Planning)
+  'Intended Audience :: Developers',
+  'Intended Audience :: System Administrators',
+  'Programming Language :: Python :: 3',
+  'Operating System :: Linux and OSX',
 ]
 
-dependencies = [
-    "requests>=2.32",
-    "simplejson>=3.19",
-]
+dependencies = ['requests>=2.32', 'simplejson>=3.19']
+
+[project.optional-dependencies]
+cli = ['click~=8.1.8', 'PyYAML~=6.0.2']
+dev = ['ruff', 'twine']
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.format]
+quote-style = 'single'
+
+[project.scripts]
+dqclient = 'dqclient.cli:cli'
 
 [project.urls]
-Repository = "https://github.com/django-daiquiri/client"
-Issues = "https://github.com/django-daiquiri/client/issues"
+Repository = 'https://github.com/django-daiquiri/client'
+Issues = 'https://github.com/django-daiquiri/client/issues'
+
 
 [tool.setuptools.dynamic]
-version = {attr = "daiquiri_client.__version__"}
+version = { attr = 'daiquiri_client.__version__' }
 
 [tool.setuptools]
-packages = [
-    "daiquiri_client",
-]
+packages = ['daiquiri_client', 'dqclient']
 include-package-data = false


### PR DESCRIPTION
This PR adds a handy CLI tool for metadata management. 
No need to write scripts for each data archive anymore. Simplifies update of the metadata and backup of the metadata.

CLI can be installed via
```bash
pip install .[cli]
```

__Example 1__,  list all available tables + schemas on <host_url>
```bash
dqclient metadata ls -h <host_url> -t <API Token>
```

__Example 2__, get all metadata from <host_url> and save it in a yaml file
```bash
dqclient metadata pull -h <host_url> -t <API Token> -o metadata.yml
```

The possible options or sub-commands can be listed using `--help`
```bash
dqclient --help
dqclient metadata --help
dqclient metadata push --help
```